### PR TITLE
Unset X-Request-With header during  requests.

### DIFF
--- a/app/services/authserviceapi.js
+++ b/app/services/authserviceapi.js
@@ -66,7 +66,7 @@ core.service("AuthServiceApi",function($http, $timeout, StorageService) {
 
         if (!AuthServiceApi.pendingRefresh) {
 
-            AuthServiceApi.pendingRefresh = $http.get(url, {withCredentials: true}).
+            AuthServiceApi.pendingRefresh = $http.get(url, {withCredentials: true, headers: {'X-Requested-With': undefined}}).
                 then(function(response) {
 
                         StorageService.set('token', response.data.tokenAsString);

--- a/app/services/restapi.js
+++ b/app/services/restapi.js
@@ -156,7 +156,8 @@ core.service("RestApi",function($http, $window, AuthServiceApi) {
 			data: req.file,
 			headers: {
 				'jwt': sessionStorage.token, 
-				'data': data
+				'data': data,
+				'X-Requested-With': undefined
 			}
 		};
 


### PR DESCRIPTION
This was causing error responses when attempting to get a refresh token.
