### PR TITLE
Adding default color values to theme sass.

### DIFF
--- a/app/resources/styles/sass/theme-base.scss
+++ b/app/resources/styles/sass/theme-base.scss
@@ -1,3 +1,11 @@
+$primary: #500000;
+
+$secondary: #3c0000;
+
+$linkColor: #337ab7;
+
+$baseFontSize: 14px;
+
 html {
     font-size: $baseFontSize;
 }


### PR DESCRIPTION
When not using the Weaver Service theme manager, the Angular app would be missing default sass values. This allows an Angular app using the Weaver UI to have default values.
