### PR TITLE
Added a manifest argument to the fetch method

### DIFF
--- a/app/services/wsapi.js
+++ b/app/services/wsapi.js
@@ -52,7 +52,18 @@ core.service("WsApi", function($q, $http, WsService, AuthServiceApi) {
 	 *  websocket communication on the desired channel
 	 * 
 	 */
-	WsApi.fetch = function(apiReq) {
+	WsApi.fetch = function(apiReq, manifest) {
+
+		if(manifest && manifest.pathValues) {
+			var templateKeys = Object.keys(manifest.pathValues);
+			for(var i in templateKeys) {
+				var key = templateKeys[i];
+				var value = manifest.pathValues[key];
+				apiReq.method=apiReq.method.replace(new RegExp(':'+key, 'g'), value);
+			}
+		}
+
+		if(manifest && manifest.data) apiReq.data = manifest.data;
 
 		var request = '/ws/' + apiReq.controller + '/' + apiReq.method;	  
 		var channel = apiReq.endpoint + "/" + apiReq.controller + "/" + apiReq.method;


### PR DESCRIPTION
Added a second argument to the fetch method which allows you to pass both data, and pathValues in. This allows you to not have to angular.extend the apiMapping before fetching. This should not lead to any issues with calls to fetch which don't pass the second argument (i.e. backwards compatible).