### PR TITLE
Allow setting httpmethod in ApiMapping

### DIFF
--- a/app/services/wsApi.js
+++ b/app/services/wsApi.js
@@ -129,7 +129,7 @@ core.service("WsApi", function ($q, $location, $rootScope, RestApi, WsService) {
 
         var restSend = RestApi.get;
 
-        if(manifest && (manifest.method||apiReq.httpMethod)) {
+        if((manifest && manifest.method) || apiReq.httpMethod) {
           restSend = RestApi[manifest.method||apiReq.httpMethod];
         } else {
           restSend = (apiReq.data !== undefined && apiReq.data !== null) ? RestApi.post : restSend;

--- a/app/services/wsApi.js
+++ b/app/services/wsApi.js
@@ -128,9 +128,10 @@ core.service("WsApi", function ($q, $location, $rootScope, RestApi, WsService) {
 
 
         var restSend = RestApi.get;
-
+        var httpMethod = manifest.method||apiReq.httpMethod;
+        
         if((manifest && manifest.method) || apiReq.httpMethod) {
-          restSend = RestApi[manifest.method||apiReq.httpMethod];
+          restSend = RestApi[httpMethod];
         } else {
           restSend = (apiReq.data !== undefined && apiReq.data !== null) ? RestApi.post : restSend;
         }

--- a/app/services/wsApi.js
+++ b/app/services/wsApi.js
@@ -129,8 +129,8 @@ core.service("WsApi", function ($q, $location, $rootScope, RestApi, WsService) {
 
         var restSend = RestApi.get;
 
-        if(manifest && manifest.method) {
-          restSend = RestApi[manifest.method];
+        if(manifest && (manifest.method||apiReq.httpMethod)) {
+          restSend = RestApi[manifest.method||apiReq.httpMethod];
         } else {
           restSend = (apiReq.data !== undefined && apiReq.data !== null) ? RestApi.post : restSend;
         }

--- a/app/services/wsApi.js
+++ b/app/services/wsApi.js
@@ -128,10 +128,9 @@ core.service("WsApi", function ($q, $location, $rootScope, RestApi, WsService) {
 
 
         var restSend = RestApi.get;
-        var httpMethod = manifest.method||apiReq.httpMethod;
-        
+
         if((manifest && manifest.method) || apiReq.httpMethod) {
-          restSend = RestApi[httpMethod];
+          restSend = RestApi[manifest.method||apiReq.httpMethod];
         } else {
           restSend = (apiReq.data !== undefined && apiReq.data !== null) ? RestApi.post : restSend;
         }


### PR DESCRIPTION
This will allow for a key/value of httpMethod to be created in the ApiMapping. manifest.method will take precedence over such a value, and its absence will not effect the normal operation of wsApi.fetch.

This should be considered a minor change.