### PR TITLE
Only replace the last occurrence of repo string in repo factory

### DIFF
--- a/app/core.js
+++ b/app/core.js
@@ -17,7 +17,7 @@ var core = angular.module('core', [
 ]).constant('coreConfig', coreConfig);
 
 core.repo = function (delegateName, delegateFunction) {
-    var modelName = delegateName.replace('Repo', '');
+    var modelName = delegateName.substring(0,delegateName.lastIndexOf("Repo"));
     return core.factory(delegateName, function ($injector, AbstractRepo, AbstractAppRepo, api) {
 
         delegateFunction.$inject = $injector.annotate(delegateFunction);


### PR DESCRIPTION
The core repo factory replaces the first occurrence of the string 'repo' when generating model names.

For example, a repo named 'ProjectRepositoryRepo' becomes 'ProjectsitoryRepo' instead of 'ProjectRepository'.