### PR TITLE
Converting defer to promise

### DIFF
--- a/app/model/abstractModel.js
+++ b/app/model/abstractModel.js
@@ -125,7 +125,7 @@ core.factory("AbstractModel", function ($injector, $rootScope, $q, $timeout, Mod
 
         this.ready = function () {
             var aggDefer = $q.defer();
-            beforePromises.push(defer);
+            beforePromises.push(defer.promise);
             $q.all(beforePromises).then(function(result) {
               aggDefer.resolve(result[0]);
             });


### PR DESCRIPTION
In the abstractModel, the defer was being added to the beforePromises
without being converted to a promise first. This caused the ready method
to resolve before the model could finish instantiating.