### PR TITLE
Improve error handling response as exposed during vireo sprint32

### DIFF
--- a/app/services/fileService.js
+++ b/app/services/fileService.js
@@ -19,11 +19,7 @@ core.service("FileService", function ($http, $q, AlertService, AuthService, Uplo
             },
             // error callback
             function (error) {
-                console.log(error);
-                AlertService.add({
-                    status: "ERROR",
-                    message: '(' + error.data.status + ') ' + error.data.message
-                }, error.data.path);
+                addAlertServiceError(error);
                 return {
                     meta: {
                         status: 'ERROR'
@@ -85,11 +81,7 @@ core.service("FileService", function ($http, $q, AlertService, AuthService, Uplo
                     },
                     // error callback
                     function (error) {
-                        console.log(error);
-                        AlertService.add({
-                            status: "ERROR",
-                            message: '(' + error.data.status + ') ' + error.data.message
-                        }, error.data.path);
+                        addAlertServiceError(error);
                         return {
                             meta: {
                                 status: 'ERROR'
@@ -109,11 +101,7 @@ core.service("FileService", function ($http, $q, AlertService, AuthService, Uplo
                     },
                     // error callback
                     function (error) {
-                        console.log(error);
-                        AlertService.add({
-                            status: "ERROR",
-                            message: '(' + error.data.status + ') ' + error.data.message
-                        }, error.data.path);
+                        addAlertServiceError(error);
                         return {
                             meta: {
                                 status: 'ERROR'
@@ -166,11 +154,7 @@ core.service("FileService", function ($http, $q, AlertService, AuthService, Uplo
             }
             defer.resolve(response);
         }, function (error) {
-            console.log(error);
-            AlertService.add({
-                status: "ERROR",
-                message: '(' + error.data.status + ') ' + error.data.message
-            }, error.data.path);
+            addAlertServiceError(error);
             defer.reject({
                 meta: {
                     status: 'ERROR'
@@ -184,4 +168,22 @@ core.service("FileService", function ($http, $q, AlertService, AuthService, Uplo
         return defer.promise;
     };
 
+    var addAlertServiceError = function(error) {
+        var status;
+        var message;
+        console.log(error);
+        if (error.data.status !== undefined) {
+            status = error.data.status;
+            message = error.data.message;
+        } else if (error.status !== undefined) {
+            status = error.status;
+            message = error.data.meta.message === undefined ? error.statusText : error.data.meta.message;
+        }
+        if (status !== undefined) {
+            AlertService.add({
+                status: "ERROR",
+                message: '(' + status + ') ' + message
+            }, error.data.path);
+        }
+    };
 });


### PR DESCRIPTION
Move the error handling to a single function to reduce repition.
Do not add any alert if the error status is null (to avoid confusing the user).

There is room for improvement in handling `error.data.meta.message`, `error.statusText`, `error.status`, and `error.data.meta.status`.
The `error.statusText` is often an empty string.
The `error.data.meta.message` is sometimes populated with desirable error messages.
The `error.status` is often the HTTP error code.
The `error.data.meta.status` is often the string **ERROR**.

If `error.data.meta.status` is used, then the error message looks like:
  `ERROR: (ERROR) File size limit exceeded`
By using the `error.status`, then the error mesages looks like:
  `ERROR: (413) File size limit exceeded`