### PR TITLE
The repo array list should not be directly alterable outside of its scope

### DIFF
--- a/app/repo/abstractRepo.js
+++ b/app/repo/abstractRepo.js
@@ -90,7 +90,7 @@ core.service("AbstractRepo", function ($q, $rootScope, $timeout, ApiResponseActi
         };
 
         abstractRepo.getContents = function () {
-            return list;
+            return angular.extend([], list);
         };
 
         abstractRepo.setToUpdate = function (id) {


### PR DESCRIPTION
When abstractRepo.getContents() is called, it returns the actual internal array list object.
This exposes the repo array list outside of its internal variable scope.
This allows for unintended changes to the repo array list.

Instead, provide a copy of the array while preserving the original objects.
This prevents the repo array list from being tampered with (intentionally or not).

This fixes issues such as when ngTables adds 'visibleColumnCount' to the repo array list.
When that gets added and abstractRepo.contains(modelJson) is later called, false positives may prevent entries from appearing in the table.
For example, if 'visibleColumnCount' is 4 and some object has an id of 4, that object will never appear because abstractRepo.contains() will claim that '4' already exists in the table.
In this case ngTables is modifying the array list that is passed to it for its own internal designs.