### PR TITLE
Changed source of path and removed route change

### DIFF
--- a/app/services/accessControlService.js
+++ b/app/services/accessControlService.js
@@ -26,11 +26,10 @@ core.service("AccessControlService", function ($location, StorageService) {
         var authorizeUrl = StorageService.get("post_authorize_url");
 
         if (role === 'ROLE_ANONYMOUS') {
-            StorageService.set("post_authorize_url", $location.path());
+            StorageService.set("post_authorize_url", window.location.pathname);
             $location.path("/error/401");
         } else if (authorizeUrl && $location.path() !== "/error/401") {
             StorageService.delete("post_authorize_url");
-            $location.path(authorizeUrl);
         } else if (restrict) {
             evt.preventDefault();
             $location.path("/error/403");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wvr/core",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Weaver AngularJs Core Module",
   "repository": " https://github.com/TAMULib/Weaver-UI-Core.git",
   "license": "MIT",


### PR DESCRIPTION
[$location.path()](https://docs.angularjs.org/guide/$location#comparing-location-to-window-location-) does not include the context path/document root so
window.location.pathname needs to be used in this context.

Due to other changes, redirecting to the authorizeUrl was sending the
user to an error page, when removing the line gave the desired result.