### PR TITLE
wvr stop cli stops all, should stop only the specific service

### DIFF
--- a/cli/server.js
+++ b/cli/server.js
@@ -14,7 +14,7 @@ function run(args) {
     if (start) {
       startServer(args);
     } else {
-      stopServer();
+      stopServer(args);
     }
 
   } else {
@@ -24,7 +24,13 @@ function run(args) {
 }
 
 function stopServer() {
-  forever.stopAll();
+  var uid = args["--uid"] ? args["--uid"] : null;
+
+  if (uid) {
+    forever.stop(uid);
+  } else {
+    forever.stopAll();
+  }
 }
 
 function startServer(args) {


### PR DESCRIPTION
When running multiple services, such as when using different ports, calling `@wvr stop` will stop all services.
Instead just stop the desired service.

To avoid breaking changes and preserve backward compatibility, when no uid is specified, call `stopAll`.

To utilize this, update the package.json and add the appropriate `--uid` parameter in the stop, just like its done in the start.