### PR TITLE
Replace affiliation scope variable with a scope function getUserAffiliation().

### DIFF
--- a/app/directives/userDirective.js
+++ b/app/directives/userDirective.js
@@ -87,18 +87,18 @@ core.directive('useruin', function () {
  */
 core.directive('useraffiliation', function (UserService) {
     return {
-        template: '<span>{{ affiliation }}</span>',
+        template: '<span>{{ getUserAffiliation() }}</span>',
         restrict: 'E',
         scope: true,
         controller: 'UserController',
         link: function ($scope, element, attr) {
-            UserService.userReady().then(function () {
+            $scope.getUserAffiliation = function() {
                 if ($scope.user.affiliation) {
-                    $scope.affiliation = $scope.user.affiliation.toUpperCase().split(';')[0];
-                } else {
-                    $scope.affiliation = "UNKNOWN";
+                    return $scope.user.affiliation.toUpperCase().split(';')[0];
                 }
-            });
+
+                return "UNKNOWN";
+            };
         }
     };
 });


### PR DESCRIPTION
Take advantage of the digest cycle to ensure that any changes to the affiliation are reflected in the directive.

For a more complete fix the following is also needed:
- TAMULib/Weaver-Webservice-Core#130

These set of fixes only fix the case where the wrong users information is presented.