### PR TITLE
Enable support for SSL by simply dropping an ssl.crt and an ssl.key in the directory.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "forever": "4.0.2",
     "forever-monitor": "1.7.1",
     "html5-boilerplate": "6.1.0",
+    "https": "^1.0.0",
     "jquery": "3.4.1",
     "ng-file-upload": "12.2.13",
     "sockjs-client": "1.4.0",

--- a/weaver-webserver.js
+++ b/weaver-webserver.js
@@ -3,6 +3,7 @@ var process = require('process');
 var path = require('path');
 
 var express = require('express');
+var https = require('https');
 var app = express();
 var router = express.Router();
 
@@ -28,13 +29,36 @@ router.use(function (req, res, next) {
 
 app.use(base, router);
 
+var sslCert = "ssl.crt";
+var sslKey = "ssl.key";
+var useSSL = true;
 
-app.listen(port, function () {
-    console.log(getTime() + ': Listening on port ' + port + ' at ' + base);
-});
+try {
+    fs.accessSync(sslCert, fs.constants.R_OK);
+    fs.accessSync(sslKey, fs.constants.R_OK);
+} catch (err) {
+    useSSL = false;
+}
+
+if (useSSL) {
+    var credentials = {
+        cert: fs.readFileSync(sslCert),
+        key: fs.readFileSync(sslKey)
+    };
+
+    var ssl = https.createServer(credentials, app);
+
+    ssl.listen(port, function () {
+        console.log(getTime() + ': Listening with SSL on port ' + port + ' at ' + base);
+    });
+} else {
+    app.listen(port, function () {
+        console.log(getTime() + ': Listening on port ' + port + ' at ' + base);
+    });
+}
 
 function getTime() {
     return new Date().toISOString().
-    replace(/T/, ' '). // replace T with a space
-    replace(/\..+/, ''); // delete the dot and everything after
+        replace(/T/, ' '). // replace T with a space
+        replace(/\..+/, ''); // delete the dot and everything after
 }


### PR DESCRIPTION
This is helpful for running Weaver UI projects in a development environment with SSL.

When both the `ssl.crt` and the `ssl.key` files are missing, the service should automatically use the classic non-HTTPS mode.

Example SSL self-signed cert generation using openssl (with 40 days expiration):
```
openssl genrsa -out ssl.key 4096

openssl req -new -key ssl.key -out ssl.csr

openssl x509 -req -days 40 -in ssl.csr -signkey ssl.key -out ssl.crt
```

When using SSL, any socket URLs will need to be in SSL.
If you get an error like:
```
SecurityError: An insecure SockJS connection may not be initiated from a page loaded over HTTPS
```

Then you have a non-HTTPS URL somewhere in a configuration that is used for SockJS connections.
Change this to HTTPS.