### PR TITLE
Vireo Issue 1536: Logout should return the user to the main page instead of an error/401 page.

### DIFF
--- a/app/controllers/authenticationController.js
+++ b/app/controllers/authenticationController.js
@@ -91,8 +91,7 @@ core.controller('AuthenticationController', function ($controller, $location, $s
         StorageService.set("role", appConfig.anonymousRole);
         $scope.user.logout();
         angular.element(".dropdown").dropdown("toggle");
-        $location.path('/');
-        $window.location.reload();
+        $window.location.assign("/");
     };
 
 });

--- a/app/controllers/authenticationController.js
+++ b/app/controllers/authenticationController.js
@@ -17,7 +17,7 @@
  *  Extends {@link core.controller:AbstractController 'AbstractController'}
  *
  **/
-core.controller('AuthenticationController', function ($controller, $location, $scope, $window, UserService, StorageService) {
+core.controller('AuthenticationController', function ($browser, $controller, $location, $scope, $window, UserService, StorageService) {
 
     angular.extend(this, $controller('AbstractController', {
         $scope: $scope
@@ -91,7 +91,7 @@ core.controller('AuthenticationController', function ($controller, $location, $s
         StorageService.set("role", appConfig.anonymousRole);
         $scope.user.logout();
         angular.element(".dropdown").dropdown("toggle");
-        $window.location.assign("/");
+        $window.location.assign($browser.baseHref());
     };
 
 });

--- a/app/controllers/loginController.js
+++ b/app/controllers/loginController.js
@@ -11,9 +11,10 @@ core.controller('LoginController', function ($controller, $location, $scope, $wi
                 var authorizeUrl = StorageService.get("post_authorize_url");
                 if (authorizeUrl) {
                     StorageService.delete("post_authorize_url");
-                    $location.path(authorizeUrl);
+                    $window.location.assign(authorizeUrl);
+                } else {
+                    $window.location.reload();
                 }
-                $window.location.reload();
             });
         });
     };


### PR DESCRIPTION
The location.path() command
```
$location.path('/');
```
does result in going to the '/' path.

However, the `$window.location` still has the original path.
When `$window.location.reload();` is called, the original path (such as '/admin/list') is reloaded!

This results in:
1) A multiple page load condition where the page load and all the related stuff happens on `$location.path('/');` and then happens again with `$window.location.reload();`.
2) A redirect back to the original path, such as '/admin/list'.
3) The user is logged out, so the page gets redirected to a 401 Unauthorized page.

Avoid all of this by instead using the function:
```
$window.location.assign();
```

The `$window.location.assign();` function performs exactly what is desired here.
The page is fully redirected to the new path (and preserves the browser history).

The login controller should also use `$window.location.assign();` to avoid the multiple load condition where things are being loaded multiple times.

The multiple load condition probably creates race conditions where data, such as cookies/session-storage, might begin being loaded on the first load and then have a partially loaded state when performing the page reload.

This uses `$browser.baseHref()` rather than `/` to avoid making assumptions and to use what angularjs is claiming the website's index is.

This is intended to solve: TexasDigitalLibrary/Vireo#1536