### PR TITLE
The abstractRepo.contains() doesn't always get an object.

### DIFF
--- a/app/repo/abstractRepo.js
+++ b/app/repo/abstractRepo.js
@@ -36,10 +36,12 @@ core.service("AbstractRepo", function ($q, $rootScope, $timeout, ApiResponseActi
 
         abstractRepo.contains = function (model) {
             var contains = false;
-            for (var i in list) {
-                if (angular.toJson(list[i]) === angular.toJson(model.id)) {
-                    contains = true;
-                    break;
+            if (angular.isObject(model) && angular.isDefined(model.id)) {
+                for (var i in list) {
+                    if (angular.toJson(list[i]) === angular.toJson(model.id)) {
+                        contains = true;
+                        break;
+                    }
                 }
             }
             return contains;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wvr/core",
-  "version": "2.2.2-rc.2",
+  "version": "2.2.2-rc.7",
   "description": "Weaver AngularJs Core Module",
   "repository": " https://github.com/TAMULib/Weaver-UI-Core.git",
   "license": "MIT",


### PR DESCRIPTION
On unauthorized responses, a string such as `UNAUTHORIZED` and then `null` appears as the `model`.
Only operate on the `model` if it is in fact an object with the property `id`.

When `model` doesn't have an `id` this function always return false (and should return false).