### PR TITLE
Add support for running a local NPM Registry via Verdaccio.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ app/bower_components
 app/resources/styles/*
 !app/resources/styles/sass/
 
+.npmrc
 .verdaccio

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ app/config/appConfig.js
 app/bower_components
 app/resources/styles/*
 !app/resources/styles/sass/
+
+.verdaccio

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# Work-around NPM trying to fake authentication and allow anonymous publishing.
+//localhost:4873/:_authToken="fake"

--- a/.npmrc-localhost
+++ b/.npmrc-localhost
@@ -1,2 +1,4 @@
 # Work-around NPM trying to fake authentication and allow anonymous publishing.
+# This file must be copied to the .npmrc of the project in order to work.
 //localhost:4873/:_authToken="fake"
+registry=http://localhost:4873/

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "update-webdriver": "webdriver-manager update",
     "preprotractor": "npm run update-webdriver",
     "protractor": "protractor e2e-tests/protractor.conf.js",
-    "start:npm-local": "verdaccio --listen localhost:4873 --config ./verdaccio-config.yaml"
+    "start:npm-local": "verdaccio --listen localhost:4873 --config ./verdaccio-config.yaml",
+    "publish:local": "npm run copy .npmrc-localhost .npmrc && npm publish ; rimraf .npmrc"
   },
   "dependencies": {
     "angular": "1.8.2",
@@ -40,6 +41,7 @@
     "stompjs": "2.3.3"
   },
   "devDependencies": {
+    "copy": "^0.3.2",
     "grunt": "1.4.1",
     "grunt-cli": "^1.4.3",
     "grunt-contrib-jshint": "^3.2.0",
@@ -54,6 +56,7 @@
     "karma-junit-reporter": "2.0.1",
     "karma-ng-html2js-preprocessor": "1.0.0",
     "protractor": "7.0.0",
+    "rimraf": "^3.0.2",
     "verdaccio": "^5.13.1",
     "verdaccio-memory": "^10.3.0"
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "preupdate-webdriver": "npm install",
     "update-webdriver": "webdriver-manager update",
     "preprotractor": "npm run update-webdriver",
-    "protractor": "protractor e2e-tests/protractor.conf.js"
+    "protractor": "protractor e2e-tests/protractor.conf.js",
+    "start:npm-local": "verdaccio --listen localhost:4873 --config ./verdaccio-config.yaml"
   },
   "dependencies": {
     "angular": "1.8.2",
@@ -52,6 +53,8 @@
     "karma-jasmine": "4.0.2",
     "karma-junit-reporter": "2.0.1",
     "karma-ng-html2js-preprocessor": "1.0.0",
-    "protractor": "7.0.0"
+    "protractor": "7.0.0",
+    "verdaccio": "^5.13.1",
+    "verdaccio-memory": "^10.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "update-webdriver": "webdriver-manager update",
     "preprotractor": "npm run update-webdriver",
     "protractor": "protractor e2e-tests/protractor.conf.js",
-    "start:npm-local": "verdaccio --listen localhost:4873 --config ./verdaccio-config.yaml",
-    "publish:local": "npm run copy .npmrc-localhost .npmrc && npm publish ; rimraf .npmrc"
+    "start:registry": "verdaccio --listen localhost:4873 --config ./verdaccio-config.yaml",
+    "publish:local": "shx cp .npmrc-localhost .npmrc && npm publish ; shx rm -f .npmrc"
   },
   "dependencies": {
     "angular": "1.8.2",
@@ -41,7 +41,6 @@
     "stompjs": "2.3.3"
   },
   "devDependencies": {
-    "copy": "^0.3.2",
     "grunt": "1.4.1",
     "grunt-cli": "^1.4.3",
     "grunt-contrib-jshint": "^3.2.0",
@@ -56,7 +55,7 @@
     "karma-junit-reporter": "2.0.1",
     "karma-ng-html2js-preprocessor": "1.0.0",
     "protractor": "7.0.0",
-    "rimraf": "^3.0.2",
+    "shx": "^0.3.4",
     "verdaccio": "^5.13.1",
     "verdaccio-memory": "^10.3.0"
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "preprotractor": "npm run update-webdriver",
     "protractor": "protractor e2e-tests/protractor.conf.js",
     "start:registry": "verdaccio --listen localhost:4873 --config ./verdaccio-config.yaml",
-    "publish:local": "shx cp .npmrc-localhost .npmrc && npm publish ; shx rm -f .npmrc"
+    "publish:local": "npm publish",
+    "prepublish:local": "shx cp .npmrc-localhost .npmrc",
+    "postpublish:local": "shx rm -f .npmrc"
   },
   "dependencies": {
     "angular": "1.8.2",

--- a/verdaccio-config.yaml
+++ b/verdaccio-config.yaml
@@ -1,0 +1,61 @@
+# https://verdaccio.org/docs/configuration/
+
+# Path to a directory with all packages.
+storage: .verdaccio/storage
+
+# Path to a directory with plugins to include.
+plugins: .verdaccio/plugins
+
+web:
+  title: Verdaccio - Weaver - Localhost
+
+  # Disable login requirement for localhost.
+  login: false
+
+# List of other known repositories to use.
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    cache: false
+
+# For verdaccio-memory, designate memory limit.
+# Comment this out to store package in .verdaccio directory rather than in memory.
+store:
+  memory:
+    limit: 10000
+
+packages:
+  '@wvr/*':
+    # Choices: "$all", "$anonymous", "$authenticated".
+    access: $all
+    publish: $all
+    unpublish: $all
+
+  '**':
+    access: $all
+
+    # Proxy non-local packages to 'npmjs' registry.
+    proxy: npmjs
+
+# Allow for publishing while offline.
+publish:
+  allow_offline: true
+
+server:
+  keepAliveTimeout: 60
+
+security:
+  api:
+    jwt:
+      sign:
+        expiresIn: 15d
+        notBefore: 0
+  web:
+    sign:
+      expiresIn: 1h
+
+middlewares:
+  audit:
+    enabled: true
+
+logs: { type: stdout, format: pretty, level: http }


### PR DESCRIPTION
A single new npm run command is added "start:registry".
This will start an Verdaccio Registry and handle only the `@wvr` packages.
All other packages are proxied.
Custom settings are added to ensure that this does not cache proxied packages (the packages from the upstream NPM Registry).

This is designed to operate anonymously.
A connection to the local Verdaccio NPM Registry should not need an account.
The more recent versions of NPM have made this more difficult by removing anonymous support.
This is worked around by adding a .npmrc that injects a fake token specifically for the localhost registry.o

This utilizes a verdaccio-memory module to have verdaccio store the registry in memory, keeping the local filesystem clean.
This can be disabled by uncommenting the the appropriate section.
The rest of the registry is already configured to work if the in-memory support is disabled.
If uncommented, then be sure to handle cleaning up the .verdaccio directory yourself.

I wanted to have the following in the package.json:
```
  "publishConfig": {
    "access": "public",
    "registry": "http://localhost:4873/"
  },
```
Which would also necessitate the following in `.npmrc`:
```
registry=http://localhost:4873/
```

This cannot happen because the NPM developers have yet to realize the usefullness of a command line argument like `--registry`:
```
npm publish --registry https://registry.npmjs.org
```

The lack of the command like argument necessitates calling a custom npm command to publish locallly:
```
npm run publish:local
```

This increases the possibility of mistakes, so I suggest always performing a dry run as a practice before actual publishing:
```
npm run publish:local --dry-run
```

There are also additional configurations that reduce the needed changes for custom situations.
1) The `allow_offline` is enabled because localhost interaction should not require an active internet connection.
2) The `security.*` settings are provided in case one wants to set `web.login` to `true`.