### PR TITLE
Add support for running a local NPM Registry via Verdaccio.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ tmp/
 npm-debug.log
 package-lock.json
 yarn.lock
+
+.npmrc
+.verdaccio

--- a/.npmrc-localhost
+++ b/.npmrc-localhost
@@ -1,0 +1,4 @@
+# Work-around NPM trying to fake authentication and allow anonymous publishing.
+# This file must be copied to the .npmrc of the project in order to work.
+//localhost:4873/:_authToken="fake"
+registry=http://localhost:4873/

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "test:watch": "karma start karma.conf.js",
     "test:ci": "karma start karma.conf.js --no-auto-watch --single-run --browsers=ChromeHeadless",
     "start:registry": "verdaccio --listen localhost:4873 --config ./verdaccio-config.yaml",
-    "publish:local": "shx cp .npmrc-localhost .npmrc && npm publish ; shx rm -f .npmrc"
+    "publish:local:pre": "shx cp .npmrc-localhost .npmrc",
+    "publish:local": "npm publish",
+    "publish:local:post": "shx rm -f .npmrc"
   },
   "dependencies": {
     "angular": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "test:watch": "karma start karma.conf.js",
     "test:ci": "karma start karma.conf.js --no-auto-watch --single-run --browsers=ChromeHeadless",
     "start:registry": "verdaccio --listen localhost:4873 --config ./verdaccio-config.yaml",
-    "publish:local:pre": "shx cp .npmrc-localhost .npmrc",
     "publish:local": "npm publish",
-    "publish:local:post": "shx rm -f .npmrc"
+    "prepublish:local": "shx cp .npmrc-localhost .npmrc",
+    "postpublish:local": "shx rm -f .npmrc"
   },
   "dependencies": {
     "angular": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "test": "karma start karma.conf.js --single-run",
     "test:watch": "karma start karma.conf.js",
-    "test:ci": "karma start karma.conf.js --no-auto-watch --single-run --browsers=ChromeHeadless"
+    "test:ci": "karma start karma.conf.js --no-auto-watch --single-run --browsers=ChromeHeadless",
+    "start:registry": "verdaccio --listen localhost:4873 --config ./verdaccio-config.yaml",
+    "publish:local": "shx cp .npmrc-localhost .npmrc && npm publish ; shx rm -f .npmrc"
   },
   "dependencies": {
     "angular": "^1.8.2",
@@ -54,5 +56,10 @@
     "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2",
     "webpack-extract-module-to-global": "^0.1.0"
+  },
+  "devDependencies": {
+    "shx": "^0.3.4",
+    "verdaccio": "^5.13.2",
+    "verdaccio-memory": "^10.3.0"
   }
 }

--- a/verdaccio-config.yaml
+++ b/verdaccio-config.yaml
@@ -1,0 +1,61 @@
+# https://verdaccio.org/docs/configuration/
+
+# Path to a directory with all packages.
+storage: .verdaccio/storage
+
+# Path to a directory with plugins to include.
+plugins: .verdaccio/plugins
+
+web:
+  title: Verdaccio - Weaver - Localhost
+
+  # Disable login requirement for localhost.
+  login: false
+
+# List of other known repositories to use.
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    cache: false
+
+# For verdaccio-memory, designate memory limit.
+# Comment this out to store package in .verdaccio directory rather than in memory.
+store:
+  memory:
+    limit: 10000
+
+packages:
+  '@wvr/*':
+    # Choices: "$all", "$anonymous", "$authenticated".
+    access: $all
+    publish: $all
+    unpublish: $all
+
+  '**':
+    access: $all
+
+    # Proxy non-local packages to 'npmjs' registry.
+    proxy: npmjs
+
+# Allow for publishing while offline.
+publish:
+  allow_offline: true
+
+server:
+  keepAliveTimeout: 60
+
+security:
+  api:
+    jwt:
+      sign:
+        expiresIn: 15d
+        notBefore: 0
+  web:
+    sign:
+      expiresIn: 1h
+
+middlewares:
+  audit:
+    enabled: true
+
+logs: { type: stdout, format: pretty, level: http }


### PR DESCRIPTION
A single new npm run command is added "start:registry".
This will start an Verdaccio Registry and handle only the `@wvr` packages.
All other packages are proxied.
Custom settings are added to ensure that this does not cache proxied packages (the packages from the upstream NPM Registry).

This is designed to operate anonymously.
A connection to the local Verdaccio NPM Registry should not need an account.
The more recent versions of NPM have made this more difficult by removing anonymous support.
This is worked around by adding a .npmrc that injects a fake token specifically for the localhost registry.o

This utilizes a verdaccio-memory module to have verdaccio store the registry in memory, keeping the local filesystem clean.
This can be disabled by uncommenting the the appropriate section.
The rest of the registry is already configured to work if the in-memory support is disabled.
If uncommented, then be sure to handle cleaning up the .verdaccio directory yourself.

I wanted to have the following in the package.json:
```
  "publishConfig": {
    "access": "public",
    "registry": "http://localhost:4873/"
  },
```
Which would also necessitate the following in `.npmrc`:
```
registry=http://localhost:4873/
```

This cannot happen because the NPM developers have yet to realize the usefullness of a command line argument like `--registry`:
```
npm publish --registry https://registry.npmjs.org
```

The lack of the command like argument necessitates calling a custom npm command to publish locallly:
```
npm run publish:local
```

This increases the possibility of mistakes, so I suggest always performing a dry run as a practice before actual publishing:
```
npm run publish:local --dry-run
```

There are also additional configurations that reduce the needed changes for custom situations.
1) The `allow_offline` is enabled because localhost interaction should not require an active internet connection.
2) The `security.*` settings are provided in case one wants to set `web.login` to `true`.