### PR TITLE
Use "default" for the network and name it "weaver".

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,12 @@
 version: '3.7'
 
 networks:
-  weaver:
+  default:
+    name: weaver
 
 services:
   registry:
+    hostname: registry
     build:
       dockerfile: Dockerfile
       context: './'
@@ -12,8 +14,6 @@ services:
       - COMMAND=start:registry
     ports:
       - 4873:4873
-    networks:
-      weaver:
 
   publish:
     build:
@@ -21,7 +21,5 @@ services:
       context: './'
     environment:
       - COMMAND=publish:registry
-    networks:
-      weaver:
     depends_on:
       - registry


### PR DESCRIPTION
Use the "default" netowrk rather than use a custom network called "weaver" that is then named "weaver".
The custom networks no longer need to be specified when "default" network is used.
Explicitly name the host "registry".