### PR TITLE
Enable Verdaccio caching and storing in disk by default.

### DIFF
--- a/verdaccio-config.yaml
+++ b/verdaccio-config.yaml
@@ -16,15 +16,18 @@ web:
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
-    cache: false
+    cache: true
+
+    # Set max cache age to 40 days.
+    maxage: 40d
 
 listen: 0.0.0.0:4873
 
 # For verdaccio-memory, designate memory limit.
-# Comment this out to store package in .verdaccio directory rather than in memory.
-store:
-  memory:
-    limit: 10000
+# Uncomment this to store package in mempry rather than the .verdaccio directory.
+#store:
+#  memory:
+#    limit: 20000
 
 packages:
   '@wvr/*':

--- a/verdaccio-config.yaml
+++ b/verdaccio-config.yaml
@@ -24,7 +24,7 @@ uplinks:
 listen: 0.0.0.0:4873
 
 # For verdaccio-memory, designate memory limit.
-# Uncomment this to store package in mempry rather than the .verdaccio directory.
+# Uncomment this to store package in memory rather than the .verdaccio directory.
 #store:
 #  memory:
 #    limit: 20000


### PR DESCRIPTION
The expected default behavior is to run in docker.
It makes more sense to use local disk caching rather not caching and running from memory.

Enable caching of npmjs registry.
Set a max cache expiration large enough to always be within the sprint cycle but small enough to eventually clean itself up.

Disable storing memory by default.
The docker can always be pruned or deleted.
Using this in docker reduces some of the benefits of running from memory in terms of easier maintenance.