### PR TITLE
Support all known pattern functions and conditionally handle 'to'.

### DIFF
--- a/cli/default-webpack.config.js
+++ b/cli/default-webpack.config.js
@@ -25,10 +25,23 @@ const patterns = [];
 copy.forEach(c => {
   const pattern = {
     from: resolve(c.from),
-    to: resolve(path, c.to)
   };
   if (c.transform && c.transform instanceof Function) {
     pattern.transform = c.transform;
+  }
+  if (c.transformAll && c.transformAll instanceof Function) {
+    pattern.transformAll = c.transformAll;
+  }
+  if (c.filter && c.filter instanceof Function) {
+    pattern.filter = c.filter;
+  }
+  if (c.info && c.info instanceof Function) {
+    pattern.info = c.info;
+  }
+  if (c.to && c.to instanceof Function) {
+    pattern.to = c.to;
+  } else {
+    pattern.to = resolve(path, c.to);
   }
   patterns.push(pattern);
 });


### PR DESCRIPTION
The `to()` function is needed and is unavailable.

Add all known functions rather than add the functions and require a new release every time a function is needed.

For the case of `to`, only call `resolve()` if `to` is not a function.

see: https://www.npmjs.com/package/copy-webpack-plugin#user-content-patterns

Example Usage of the `to` function:
```js
    {
      from: './node_modules/tinymce/plugins/**/plugin.js',
      to({ context, absoluteFilename }) {
        return `${absoluteFilename.replace(/^.*\/node_modules\/tinymce\/plugins\//, "resources/tinymce/plugins/")}`;
      },
    }
```