### PR TITLE
Issue 217: Weaver authentication is making unsafe assumptions on the data and failing out incorrectly.

### DIFF
--- a/app/services/userService.js
+++ b/app/services/userService.js
@@ -13,7 +13,7 @@ core.service("UserService", function ($q, StorageService, User, WsApi) {
 
         return WsApi.fetch(currentUser.getMapping().instantiate).then(function (res) {
             var body = !res.body ? {} : angular.fromJson(res.body);
-            var credentials = { role: !currentUser.role ? "ROLE_ANONYMOUS" : currentUser.role };
+            var credentials = { role: !currentUser.role ? appConfig.anonymousRole : currentUser.role };
 
             // Only change credentials when packet structure is valid.
             if (!!body.payload && !!body.payload.Credentials) {

--- a/app/services/userService.js
+++ b/app/services/userService.js
@@ -10,10 +10,24 @@ core.service("UserService", function ($q, StorageService, User, WsApi) {
 
     UserService.fetchUser = function () {
         userEvents.notify('FETCH');
+
         return WsApi.fetch(currentUser.getMapping().instantiate).then(function (res) {
-            delete sessionStorage.role;
-            var credentials = angular.fromJson(res.body).payload.Credentials;
-            currentUser.anonymous = credentials.role === appConfig.anonymousRole ? true : false;
+            var body = !res.body ? {} : angular.fromJson(res.body);
+            var credentials = { role: !currentUser.role ? "ROLE_ANONYMOUS" : currentUser.role };
+
+            // Only change credentials when packet structure is valid.
+            if (!!body.payload && !!body.payload.Credentials) {
+              delete sessionStorage.role;
+              credentials = angular.fromJson(res.body).payload.Credentials;
+            }
+
+            currentUser.anonymous = !credentials.role || credentials.role === appConfig.anonymousRole ? true : false;
+
+            // Cannot have a token for the anonymous role.
+            if (currentUser.anonymous) {
+              StorageService.delete("token");
+            }
+
             angular.extend(currentUser, credentials);
             StorageService.set("role", currentUser.role);
             userEvents.notify('RECEIVED');

--- a/app/services/userService.js
+++ b/app/services/userService.js
@@ -12,16 +12,16 @@ core.service("UserService", function ($q, StorageService, User, WsApi) {
         userEvents.notify('FETCH');
 
         return WsApi.fetch(currentUser.getMapping().instantiate).then(function (res) {
-            var body = !res.body ? {} : angular.fromJson(res.body);
-            var credentials = { role: !currentUser.role ? appConfig.anonymousRole : currentUser.role };
+            var body = !!res && !!res.body ? angular.fromJson(res.body) : {};
+            var credentials = { role: !!currentUser.role ? currentUser.role : appConfig.anonymousRole };
 
             // Only change credentials when packet structure is valid.
-            if (!!body.payload && !!body.payload.Credentials) {
+            if (!!body && !!body.payload && !!body.payload.Credentials) {
               delete sessionStorage.role;
               credentials = angular.fromJson(res.body).payload.Credentials;
             }
 
-            currentUser.anonymous = !credentials.role || credentials.role === appConfig.anonymousRole ? true : false;
+            currentUser.anonymous = !credentials.role || credentials.role === appConfig.anonymousRole;
 
             // Cannot have a token for the anonymous role.
             if (currentUser.anonymous) {


### PR DESCRIPTION
# Description

When an error occurs either a valid error payload is returned or something else is returned. Do not be opinionated about errors payloads here because the fetchUser should not care at this time.

Preserve the original user role and if it is not defined then set the role to ROLE_ANONYMOUS. Only when the payload has a valid Credentials structure should the session role be deleted and the credentials object be modified.

Having a token when the payload is invalid or the role is anonymous  results in an error message getting stuck. Delete the token in the case that the role is anonymous. After all, the anonymous user should not have a token.

Continue to perform the completion steps needed to resolve the fetchUser request regardless of the payload structure.


Fixes #217

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran using verdaccio via localhost against both good and bad auth URL.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

