### PR TITLE
Issue 221: Return to Safety, results in going back to 403.

### DIFF
--- a/app/controllers/errorPageController.js
+++ b/app/controllers/errorPageController.js
@@ -1,5 +1,25 @@
 core.controller("ErrorPageController", function ($scope, AccessControlService) {
 
-    $scope.lastRoute = AccessControlService.getLastRoutePath();
+    $scope.getPath = function (path) {
+
+      if (!!path && path.length > 0) {
+        var paths = path.split('/');
+
+        for (var i in paths) {
+          // Return to top-level when previous path contains route variables.
+          if (paths[i][0] === ':') {
+            paths = [];
+            break;
+          }
+        }
+
+        return paths.join('/');
+      }
+
+      return path;
+    };
+
+    // This is actually a URL path and not a route.
+    $scope.lastRoute = $scope.getPath(AccessControlService.getLastRoutePath());
 
 });

--- a/app/controllers/errorPageController.js
+++ b/app/controllers/errorPageController.js
@@ -1,25 +1,25 @@
 core.controller("ErrorPageController", function ($scope, AccessControlService) {
 
-    $scope.getPath = function (path) {
+  $scope.getPath = function (path) {
 
-      if (!!path && path.length > 0) {
-        var paths = path.split('/');
+    if (!!path && path.length > 0) {
+      var paths = path.split('/');
 
-        for (var i in paths) {
-          // Return to top-level when previous path contains route variables.
-          if (paths[i][0] === ':') {
-            paths = [];
-            break;
-          }
+      for (var i in paths) {
+        // Return to top-level when previous path contains route variables.
+        if (paths[i][0] === ':') {
+          paths = [];
+          break;
         }
-
-        return paths.join('/');
       }
 
-      return path;
-    };
+      return paths.join('/');
+    }
 
-    // This is actually a URL path and not a route.
-    $scope.lastRoute = $scope.getPath(AccessControlService.getLastRoutePath());
+    return path;
+  };
+
+  // This is actually a URL path and not a route.
+  $scope.lastRoute = $scope.getPath(AccessControlService.getLastRoutePath());
 
 });


### PR DESCRIPTION
# Description

This is happening because of a double redirect.
When going to the `/management` page, a browser is redirected to `/management/internal-metadata`. Then the last route ends up referring to the `/management` page, which is the route path of `/management/:tab`. The `:tab` is not a valid part of the URL because the `$scope.lastRoute` is expected to be a path rather than a route. Rather than rename `lastRoute` to `lastPath`:
1. Add a comment describing this behavior.
2. Wrap the assignment in a function that changes the path if any route parts are found.

Fixes #221

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Used SAGE to test access denied error page rendering.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

