### PR TITLE
Issue 220: Security fixes for: minimatch and qs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "verdaccio": "^5.13.3"
   },
   "overrides": {
-    "glob-stream": "^7.0.0"
+    "glob-stream": "^7.0.0",
+    "minimatch": "^3.1.2",
+    "qs": "^6.11.0"
   }
 }


### PR DESCRIPTION
# Description

Fix child dependencies that are coming in with insecure versions. This is based on the `npm list --depth=100` and considers what is reported by dependabot for Sage.

There is a concern with `minimatch`.
One of the dependencies is trying to pull in a `5.1.0` version (or higher).

see: https://github.com/TAMULib/SAGE/security/dependabot/37
see: https://github.com/TAMULib/SAGE/security/dependabot/34

Fixes #220

## Type of change

Please delete options that are not relevant.

- [x] Security related.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Testing via local verdaccio publish and used by other projects such as SAGE.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

