### PR TITLE
Weaver Repo Lazy is too Eager.

### DIFF
--- a/app/repo/abstractRepo.js
+++ b/app/repo/abstractRepo.js
@@ -20,6 +20,8 @@ core.service("AbstractRepo", function ($q, $rootScope, $timeout, ApiResponseActi
 
         var pendingChanges;
 
+        var forceLoad = true;
+
         $rootScope.$on("$routeChangeSuccess", function () {
             angular.forEach(actionCbs, function (actionCbs) {
                 actionCbs.length = 0;
@@ -85,8 +87,9 @@ core.service("AbstractRepo", function ($q, $rootScope, $timeout, ApiResponseActi
         };
 
         abstractRepo.getAll = function () {
-            if (mapping.lazy) {
+            if (forceLoad) {
                 fetch();
+                forceLoad = false;
             }
             return abstractRepo.getContents();
         };
@@ -506,6 +509,7 @@ core.service("AbstractRepo", function ($q, $rootScope, $timeout, ApiResponseActi
 
         if (!mapping.lazy) {
             fetch();
+            forceLoad = false;
         }
 
         return abstractRepo;

--- a/app/repo/abstractRepo.js
+++ b/app/repo/abstractRepo.js
@@ -151,6 +151,7 @@ core.service("AbstractRepo", function ($q, $rootScope, $timeout, ApiResponseActi
         };
 
         abstractRepo.reset = function () {
+            forceLoad = false;
             defer = $q.defer();
             fetch();
             return defer.promise;

--- a/app/services/wsApi.js
+++ b/app/services/wsApi.js
@@ -64,7 +64,7 @@ core.service("WsApi", function ($q, $location, $rootScope, AlertService, RestApi
      * @name  core.service:WsApi#WsApi.listen
      * @methodOf core.service:WsApi
      * @param {object} apiReq
-     *  An apireq which containes the channel, controller and method
+     *  An apireq which contains the channel, controller and method
      *  which should be listened to.
      * @returns {Promsie} A promise from a websocket subscription subscription
      *


### PR DESCRIPTION
# Description

The weaver repo is always loading data, even if already loaded, when lazy is set to TRUE.

Lazy is being set to TRUE for performance improvements and for granting control when something is loaded (if at all).
But when lazy is set to TRUE, it is always loading the data rather than using the existing cached data.
This has a potentially huge performance hit for large data sets on pages depending on the circumstances.

Under certain circumstances the previous behavior can cause an infinite loop/load and crash the webbrowser.

Initial experimentation under Vireo has shown (in conjunction with other changes) the page load for a single submission view go from 10 seconds to 1 second.

May be required to fix performance problems in Vireo.

Also fix a typo in the code.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] On Vireo

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

