### PR TITLE
Provide an alternative to getAll() that returns a promise and still respects the lazy load setting.

### DIFF
--- a/app/repo/abstractRepo.js
+++ b/app/repo/abstractRepo.js
@@ -20,6 +20,8 @@ core.service("AbstractRepo", function ($q, $rootScope, $timeout, ApiResponseActi
 
         var pendingChanges;
 
+        var forceLoad = true;
+
         $rootScope.$on("$routeChangeSuccess", function () {
             angular.forEach(actionCbs, function (actionCbs) {
                 actionCbs.length = 0;
@@ -85,8 +87,9 @@ core.service("AbstractRepo", function ($q, $rootScope, $timeout, ApiResponseActi
         };
 
         abstractRepo.getAll = function () {
-            if (mapping.lazy) {
+            if (forceLoad) {
                 fetch();
+                forceLoad = false;
             }
             return abstractRepo.getContents();
         };
@@ -506,6 +509,7 @@ core.service("AbstractRepo", function ($q, $rootScope, $timeout, ApiResponseActi
 
         if (!mapping.lazy) {
             fetch();
+            forceLoad = false;
         }
 
         return abstractRepo;

--- a/app/repo/abstractRepo.js
+++ b/app/repo/abstractRepo.js
@@ -94,6 +94,21 @@ core.service("AbstractRepo", function ($q, $rootScope, $timeout, ApiResponseActi
             return abstractRepo.getContents();
         };
 
+        abstractRepo.findAll = function () {
+            return $q(function (resolve) {
+                if (forceLoad) {
+                    fetch();
+                    forceLoad = false;
+
+                    defer.promise.then(function() {
+                        resolve(abstractRepo.getContents());
+                    });
+                } else {
+                    resolve(abstractRepo.getContents());
+                }
+            });
+        };
+
         abstractRepo.getContents = function () {
             return list;
         };
@@ -261,7 +276,7 @@ core.service("AbstractRepo", function ($q, $rootScope, $timeout, ApiResponseActi
                     if (item.id === newItem.id) {
                         angular.extend(item, newItem);
                         match = true;
-                        break; 
+                        break;
                     }
                 }
 
@@ -283,7 +298,7 @@ core.service("AbstractRepo", function ($q, $rootScope, $timeout, ApiResponseActi
 
                     if (newItem.id === item.id) {
                         match = true;
-                        break; 
+                        break;
                     }
                 }
 

--- a/app/repo/abstractRepo.js
+++ b/app/repo/abstractRepo.js
@@ -151,6 +151,7 @@ core.service("AbstractRepo", function ($q, $rootScope, $timeout, ApiResponseActi
         };
 
         abstractRepo.reset = function () {
+            forceLoad = false;
             defer = $q.defer();
             fetch();
             return defer.promise;

--- a/app/services/wsApi.js
+++ b/app/services/wsApi.js
@@ -64,7 +64,7 @@ core.service("WsApi", function ($q, $location, $rootScope, AlertService, RestApi
      * @name  core.service:WsApi#WsApi.listen
      * @methodOf core.service:WsApi
      * @param {object} apiReq
-     *  An apireq which containes the channel, controller and method
+     *  An apireq which contains the channel, controller and method
      *  which should be listened to.
      * @returns {Promsie} A promise from a websocket subscription subscription
      *


### PR DESCRIPTION
# Description

Use`findAll()` for this purpose.
This better allows for the use-case where the lazy-load is loaded right before it is needed.
The current popularized design is to load everything on page view, even when lazy loaded.
    
The promise callback being returned is necessary so that the loaded values can be processed after successful load.

This is based off of changes from PR #228.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Not Tested.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code

