### PR TITLE
Ensure JS file is a regular file type and not a directory file type (or any other non-regular file type).

### DIFF
--- a/cli/default-webpack.config.js
+++ b/cli/default-webpack.config.js
@@ -81,10 +81,12 @@ for (const bundle of Object.keys(entry)) {
   }).map((e) => {
     const ext = e.split('.').pop();
     if (ext === 'js') {
-      // rename all js files to preserve order through build
+      // Rename all js files (but not directories) to preserve order through build.
       const entry = join(tempPath, `${(++i).toString().padStart(10, '0')}.js`);
-      fs.copyFileSync(e, entry);
-      return `!${extractLoader}?modules!${resolve(entry)}`;
+      if (fs.statSync(e).isFile()) {
+        fs.copyFileSync(e, entry);
+        return `!${extractLoader}?modules!${resolve(entry)}`;
+      }
     }
     return e;
   });


### PR DESCRIPTION
This fixes problems lile:
```
node:internal/fs/utils:347
    throw err;
    ^

Error: EISDIR: illegal operation on a directory, copyfile './src/main/webapp/app/node_modules/hpack.js' -> '.wvr/tmp/0000000182.js'
    at Object.copyFileSync (node:fs:2847:3)
    at node_modules/@wvr/core/cli/default-webpack.config.js:86:10
    at Array.map (<anonymous>)
    at Object.<anonymous> (node_modules/@wvr/core/cli/default-webpack.config.js:81:6)
    at Module._compile (node:internal/modules/cjs/loader:1155:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1209:10)
    at Module.load (node:internal/modules/cjs/loader:1033:32)
    at Function.Module._load (node:internal/modules/cjs/loader:868:12)
    at Module.require (node:internal/modules/cjs/loader:1057:19)
    at require (node:internal/modules/cjs/helpers:103:18) {
  errno: -21,
  syscall: 'copyfile',
  code: 'EISDIR',
  path: './src/main/webapp/app/node_modules/hpack.js',
  dest: '.wvr/tmp/0000000182.js'
}
[ERROR] Command execution failed.
org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)
```

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] On Vireo, getting past bug.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

