### PR TITLE
Include credentials with token refresh request

### DIFF
--- a/app/services/authService.js
+++ b/app/services/authService.js
@@ -77,6 +77,7 @@ core.service("AuthService", function ($http, $timeout) {
             }
 
             AuthService.pendingRefresh = $http.get(url, {
+                withCredentials: true,
                 headers: {
                     'X-Requested-With': undefined
                 }


### PR DESCRIPTION
# Description

Updates the token refresh request to include security credentials in cross domain scenarios.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials

Fixes refresh requests in scenarios where the Weaver UI client is cross domain relative to the configured auth service. Without credentials, a refresh request to a Shibboleth wrapped auth service will fail due to lack of shib credentials in the request. This can cause subtle to severe errors in the client app.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This problem manifested in the [Vireo app](https://github.com/TAMULib/Vireo/issues/60) by blocking all batch exports. This solution was tested by deploying a version of Vireo with this code fix against a corresponding shib backed auth service which had been updated to accept the credentials in cross domain scenarios.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

