### PR TITLE
Process API response without requiring it be ApiResponse

### DIFF
--- a/app/services/restApi.js
+++ b/app/services/restApi.js
@@ -30,6 +30,11 @@ core.service("RestApi", function ($http, AlertService, AuthService, HttpMethodVe
         return url;
     };
 
+    var getMeta = function (response) {
+        return !!response.data.meta ? response.data.meta
+            : { status: response.statusText, message: 'Request was successful' };
+    };
+
     /**
      * @ngdoc method
      * @name core.service:RestApi#anonymousGet
@@ -58,7 +63,7 @@ core.service("RestApi", function ($http, AlertService, AuthService, HttpMethodVe
         }).then(
             // success callback
             function (response) {
-                AlertService.add(response.data.meta, response.config.url.replace(appConfig.webService + "/", ""));
+                AlertService.add(getMeta(response), response.config.url.replace(appConfig.webService + "/", ""));
                 return response.data;
             },
             // error callback
@@ -105,7 +110,7 @@ core.service("RestApi", function ($http, AlertService, AuthService, HttpMethodVe
         }).then(
             // success callback
             function (response) {
-                AlertService.add(response.data.meta, response.config.url.replace(appConfig.webService + "/", ""));
+                AlertService.add(getMeta(response), response.config.url.replace(appConfig.webService + "/", ""));
                 return response.data;
             },
             // error callback
@@ -197,7 +202,7 @@ core.service("RestApi", function ($http, AlertService, AuthService, HttpMethodVe
         return $http(restObj).then(
             // success callback
             function (response) {
-                if (response.data.meta.status === 'REFRESH') {
+                if (!!response.data.meta && response.data.meta.status === 'REFRESH') {
                     if (sessionStorage.assumedUser) {
                         return AuthService.getAssumedUser(angular.fromJson(sessionStorage.assumedUser)).then(function () {
                             restObj.headers.jwt = sessionStorage.token;
@@ -214,7 +219,7 @@ core.service("RestApi", function ($http, AlertService, AuthService, HttpMethodVe
                         });
                     }
                 }
-                AlertService.add(response.data.meta, response.config.url.replace(appConfig.webService + "/", ""));
+                AlertService.add(getMeta(response), response.config.url.replace(appConfig.webService + "/", ""));
                 return response.data;
             },
             // error callback


### PR DESCRIPTION
The existing implementation of RestApi cannot be used with endpoints other than those responding with an [ApiResponse](https://github.com/TAMULib/Weaver-Webservice-Core/blob/2.x/core/src/main/java/edu/tamu/weaver/response/ApiResponse.java#L18) from Weaver-Webservice-Core.

This PR processed the $http response data and provides conditioning to allow non ApiReponse response bodies.