### PR TITLE
Fix webpack build regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "stompjs": "^2.3.3",
     "style-loader": "^3.3.1",
     "terser-webpack-plugin": "^5.3.3",
-    "webpack": "^5.74.0",
+    "webpack": "5.97.1",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.9.3",
     "webpack-extract-module-to-global": "^0.1.0"


### PR DESCRIPTION
# Description

The latest release of webpack can cause javascript files to get assembled out of order in the bundle, which breaks deployments.

This PR locks the webpack dependency to the last working version.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Broken deployments started working again