### PR TITLE
Check for download error response in arraybuffer

### DIFF
--- a/app/services/fileService.js
+++ b/app/services/fileService.js
@@ -100,10 +100,23 @@ core.service("FileService", function ($http, $q, AlertService, AuthService, Uplo
                     },
                     // error callback
                     function (error) {
+                        let errorMessage = "";
+                        if (error.data instanceof ArrayBuffer) {
+                            let decoder = new TextDecoder("utf-8");
+                            let result = decoder.decode(error.data);
+                            try {
+                                apiResponse = JSON.parse(result);
+                                errorMessage = apiResponse.meta.message;
+                                error.data.message = errorMessage;
+                            } catch (e) {
+                                console.log(e);
+                            }
+                        }
                         AlertService.addAlertServiceError(error);
                         return {
                             meta: {
-                                status: 'ERROR'
+                                status: 'ERROR',
+                                message: errorMessage
                             },
                             payload: error.data
                         };


### PR DESCRIPTION
# Description

There are cases where error ApiResponses must be delivered as a direct servlet outputstream: 
https://github.com/TexasDigitalLibrary/Vireo/pull/1984

In these cases, the FileService error handling needs to check for an ApiResponse in the ArrayBuffer, and pass along any specific error message provided by client services.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

