### PR TITLE
Only add alert on success as error is handled by `restApi` service

### DIFF
--- a/app/controllers/registrationController.js
+++ b/app/controllers/registrationController.js
@@ -4,6 +4,14 @@ core.controller('RegistrationController', function ($controller, $location, $sco
         $scope: $scope
     }));
 
+    const reportSuccess = function (data) {
+        if (data?.meta?.status === 'SUCCESS') {
+            $timeout(function () {
+                AlertService.add(data.meta, 'auth/register');
+            });
+        }
+    };
+
     $scope.reset = function () {
         $scope.user.clearValidationResults();
         for (var key in $scope.forms) {
@@ -23,10 +31,8 @@ core.controller('RegistrationController', function ($controller, $location, $sco
     $scope.verifyEmail = function (email) {
         $scope.user.verifyEmail(email).then(function (data) {
             $scope.reset();
-            $timeout(function () {
-                AlertService.add(data.meta, 'auth/register');
-            });
 
+            reportSuccess(data);
         });
     };
 
@@ -40,9 +46,7 @@ core.controller('RegistrationController', function ($controller, $location, $sco
 
             $location.path("/");
 
-            $timeout(function () {
-                AlertService.add(data.meta, 'auth/register');
-            });
+            reportSuccess(data);
         });
     };
 


### PR DESCRIPTION
# Description

There is a lot of room for improvement of the asynchronous request response handling and chaining promises. In this case the `restApi` was adding alert on error and resolving the promise instead of rejecting. The RegistrationController simply adds the alert regardless to handle both success and error. Additionally, if `skipErrorHandling` is used when calling `anonymousGet/Post` it will have a unhandled rejected promise. This is a quick fix to a larger inconsistent async handling issue.

Fixes #254 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

In Vireo disable SMPT in `src/main/resources/application.yml` by giving it an invalid or non-existent `app.email.host`. From there attempt to register by verifying email. It will fail and is expected to only add a single error alert feedback.
